### PR TITLE
Update action commands on show view for archived shelters and distribution points

### DIFF
--- a/app/views/distribution_points/show.html.erb
+++ b/app/views/distribution_points/show.html.erb
@@ -1,8 +1,12 @@
 <h1><%= @distribution_point.facility_name %></h1>
 
 
-<%= link_to 'Update', [:edit, @distribution_point], class: 'button button-clear' %> |
-<%= link_to 'Back', distribution_points_path, class: 'button button-clear' %>
+<% if @distribution_point.archived %>
+  <%= link_to 'Back', archived_distribution_points_path, class: 'button button-clear' %>
+<% else %>
+  <%= link_to 'Update', [:edit, @distribution_point], class: 'button button-clear' %> |
+  <%= link_to 'Back', distribution_points_path, class: 'button button-clear' %>
+<% end %>
 <% if admin? %> |
   <% if @distribution_point.archived %>
     <%= link_to 'Unarchive', unarchive_distribution_point_path(@distribution_point),

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -1,8 +1,11 @@
 <h1><%= @shelter.shelter %></h1>
 
-
-<%= link_to 'Update', [:edit, @shelter], class: 'button button-clear' %> |
-<%= link_to 'Back', shelters_path, class: 'button button-clear' %>
+<% if @shelter.active %>
+  <%= link_to 'Update', [:edit, @shelter], class: 'button button-clear' %> |
+  <%= link_to 'Back', shelters_path, class: 'button button-clear' %>
+<% else %>
+  <%= link_to 'Back', archived_shelters_path, class: 'button button-clear' %>
+<% end %>
 <% if admin? %> |
   <% if @shelter.active %>
     <%= link_to 'Archive', archive_shelter_path(@shelter),


### PR DESCRIPTION
The other action commands on the Show views were still using the unarchived paths, so this PR provides an update for those. Once this is merged, I think hurricane-response/florence-api#48 will be ready to merge.